### PR TITLE
Add info about UToronto Support Website

### DIFF
--- a/extra-assets/css/login.css
+++ b/extra-assets/css/login.css
@@ -36,14 +36,25 @@
     color: grey;
 }
 
+.announcements {
+    margin-top: 10px;
+}
+
+.announcements > div {
+    margin-top: 15px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    border: 2px dotted orange;
+}
+
 .questions {
     margin-top: 12px;
 }
 
 .questions > div {
     margin-top: 32px;
-    padding-top: 16px;
-    border-top: 2px lightgrey dotted;
+    padding-bottom: 32px;
+    border-bottom: 2px lightgrey dotted;
 }
 
 .footer {

--- a/templates/login.html
+++ b/templates/login.html
@@ -87,6 +87,15 @@
 
   </div>
 
+  <div class="col-md-8 col-md-offset-2 announcements">
+    <div>
+      <h4>* NEW * Jupyter Support Website</h4>
+
+      We have started a JupyterHub support website with documentation and tip sheets, and we will be adding more on an
+      ongoing basis. To reach the support site, please visit: <a href="https://act.utoronto.ca/jupyterhub-support">https://act.utoronto.ca/jupyterhub-support/</a>.
+    </div>
+  </div>
+
   <div class="col-md-8 col-md-offset-2 questions">
     <div>
       <h4>Are you interested in using Jupyter for Research?</h4>


### PR DESCRIPTION
Fixes https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/93.

I thought that adding an orange border around the announcement would draw a bit more attention to the support website. @yuvipanda, @ajhymangit what do you think about it?
This is how the login page would look like with this change:

![utoronto-login](https://user-images.githubusercontent.com/7579677/115535189-335b7c00-a2a1-11eb-82ef-7f5fc326a33b.png)
